### PR TITLE
Generate Slices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDE
 .vscode
+demo
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/composeml/conftest.py
+++ b/composeml/conftest.py
@@ -5,65 +5,6 @@ from .label_times import LabelTimes
 
 
 @pytest.fixture(scope="module")
-def transactions():
-    records = [
-        {
-            'transaction_time': '2014-01-01 00:44:00',
-            'amount': 21.35,
-            'customer_id': 1
-        },
-        {
-            'transaction_time': '2014-01-01 00:45:00',
-            'amount': 108.11,
-            'customer_id': 1
-        },
-        {
-            'transaction_time': '2014-01-01 00:46:00',
-            'amount': 112.53,
-            'customer_id': 1
-        },
-        {
-            'transaction_time': '2014-01-01 00:47:00',
-            'amount': 6.29,
-            'customer_id': 1
-        },
-        {
-            'transaction_time': '2014-01-01 00:48:00',
-            'amount': 47.95,
-            'customer_id': 1
-        },
-        {
-            'transaction_time': '2014-01-01 00:00:00',
-            'amount': 127.64,
-            'customer_id': 2
-        },
-        {
-            'transaction_time': '2014-01-01 00:01:00',
-            'amount': 109.48,
-            'customer_id': 2
-        },
-        {
-            'transaction_time': '2014-01-01 00:02:00',
-            'amount': 95.06,
-            'customer_id': 2
-        },
-        {
-            'transaction_time': '2014-01-01 00:03:00',
-            'amount': 78.92,
-            'customer_id': 2
-        },
-        {
-            'transaction_time': '2014-01-01 00:04:00',
-            'amount': 31.54,
-            'customer_id': 2
-        },
-    ]
-
-    df = pd.DataFrame.from_records(records)
-    return df
-
-
-@pytest.fixture(scope="module")
 def labels():
     records = [
         {

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -310,12 +310,13 @@ class LabelMaker:
             if finite_examples_per_instance:
                 progress_bar.update(n=1)
 
+                # update skipped examples for previous instance
                 if first_slice_for_instance:
                     instance += 1
-                    n = instance - 1
-                    n *= num_examples_per_instance
-                    n -= progress_bar.n
-                    progress_bar.update(n=n)
+                    skipped_examples = instance - 1
+                    skipped_examples *= num_examples_per_instance
+                    skipped_examples -= progress_bar.n
+                    progress_bar.update(n=skipped_examples)
 
             if not finite_examples_per_instance and first_slice_for_instance:
                 progress_bar.update(n=1)

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -183,7 +183,7 @@ class LabelMaker:
         else:
             intervals = iterate_by_time(start=min_data, offset=gap)
 
-        metadata = {'n_slice': 0, 'min_data': min_data}
+        metadata = {'slice': 0, 'min_data': min_data}
 
         for cutoff_time, gap_end in intervals:
             if cutoff_time > df.index[-1]:
@@ -206,7 +206,7 @@ class LabelMaker:
 
             metadata['window'] = (cutoff_time, window_end)
             metadata['gap'] = (cutoff_time, gap_end)
-            metadata['n_slice'] += 1
+            metadata['slice'] += 1
 
             if not df_slice.empty:
                 # exclude last row to avoid overlap
@@ -265,7 +265,7 @@ class LabelMaker:
 
                 yield df_slice
 
-                if df_metadata['n_slice'] >= num_examples_per_instance:
+                if df_metadata['slice'] >= num_examples_per_instance:
                     break
 
     def search(self,
@@ -310,7 +310,7 @@ class LabelMaker:
 
         progress_bar = tqdm(total=total, bar_format=bar_format, disable=not verbose, file=stdout)
         name = self.labeling_function.__name__
-        labels, n_instances = [], 0
+        labels, instance = [], 0
 
         slices = self.slice(
             df=df,
@@ -330,14 +330,14 @@ class LabelMaker:
                 label = {self.target_entity: key, 'cutoff_time': cutoff_time, name: label}
                 labels.append(label)
 
-            new_instance = metadata['n_slice'] == 1
+            new_instance = metadata['slice'] == 1
 
             if finite:
                 progress_bar.update(n=1)
 
                 if new_instance:
-                    n_instances += 1
-                    n = n_instances - 1
+                    instance += 1
+                    n = instance - 1
                     n *= num_examples_per_instance
                     n -= progress_bar.n
                     progress_bar.update(n=n)
@@ -394,7 +394,7 @@ class LabelMaker:
 
         info = {
             self.target_entity: metadata.get(self.target_entity),
-            'n_slice': metadata['n_slice'],
+            'slice': metadata['slice'],
             'window': '[{}, {})'.format(*window),
             'gap': '[{}, {})'.format(*gap),
         }

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -113,7 +113,7 @@ def iterate_by_time(index, offset, start):
         yield start, start + offset
 
         fast_forward = interval * int(elapsed / interval)
-        fast_forward = pd.Timedelta(f'{fast_forward}s')
+        fast_forward = pd.Timedelta('{}s'.format(fast_forward))
         start += fast_forward
 
     if start + offset > index[-1]:
@@ -278,8 +278,8 @@ class LabelMaker:
                     info = {
                         self.target_entity: key,
                         'slice': n_examples,
-                        'window': f'[{cutoff_time}, {window_end})',
-                        'gap': f'[{cutoff_time}, {gap_end})',
+                        'window': '[{}, {})'.format(cutoff_time, window_end),
+                        'gap': '[{}, {})'.format(cutoff_time, gap_end),
                     }
                     info = pd.Series(info).to_string()
                     print(info, end='\n\n')

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -122,7 +122,7 @@ class LabelMaker:
             df (DataFrame) : Data frame to generate data slices.
             gap (str) : Time between slices. Default value is window size.
             min_data (int or str or Timestamp) : Threshold to cutoff data.
-            drop_empty (bool) : Whether to drop empty slices.
+            drop_empty (bool) : Whether to drop empty slices. Default value is True.
 
         Returns:
             DataFrame, dict : Returns a data slice and metadata about the data slice.
@@ -207,9 +207,9 @@ class LabelMaker:
             num_examples_per_instance (int) : Number of examples per unique instance of target entity.
             minimum_data (str) : Minimum data before starting search. Default value is first time of index.
             gap (str) : Time between examples. Default value is window size.
-            metadata (bool) : Whether to return metadata about the data slice.
-            drop_empty (bool) : Whether to drop empty slices.
-            verbose (bool) : Whether to print metadata about slice.
+            metadata (bool) : Whether to return metadata about the data slice. Default value is False.
+            drop_empty (bool) : Whether to drop empty slices. Default value is True.
+            verbose (bool) : Whether to print metadata about slice. Default value is False.
 
         Returns:
             DataFrame : Slice of data.
@@ -257,10 +257,10 @@ class LabelMaker:
         Args:
             df (DataFrame) : Data frame to search and extract labels.
             num_examples_per_instance (int) : Number of examples per unique instance of target entity.
-            minimum_data (str) : Minimum data before starting search.
+            minimum_data (str) : Minimum data before starting search. Default value is first time of index.
             gap (str) : Time between examples.
-            drop_empty (bool) : Whether to drop empty slices.
-            verbose (bool) : Whether to render progress bar.
+            drop_empty (bool) : Whether to drop empty slices. Default value is True.
+            verbose (bool) : Whether to render progress bar. Default value is True.
             *args : Positional arguments for labeling function.
             **kwargs : Keyword arguments for labeling function.
 

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -332,19 +332,18 @@ class LabelMaker:
 
             new_instance = metadata['n_slice'] == 1
 
-            if new_instance:
-                n_instances += 1
-
             if finite:
                 progress_bar.update(n=1)
 
                 if new_instance:
+                    n_instances += 1
                     n = n_instances - 1
                     n *= num_examples_per_instance
                     n -= progress_bar.n
                     progress_bar.update(n=n)
 
             if not finite and new_instance:
+                n_instances += 1
                 progress_bar.update(n=1)
 
         total -= progress_bar.n

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -115,7 +115,7 @@ class LabelMaker:
         if self.window_size is not None:
             self.window_size = to_offset(self.window_size)
 
-    def get_slices(self, df, gap=None, min_data=None, drop_empty=True):
+    def _get_slices(self, df, gap=None, min_data=None, drop_empty=True):
         """Generate data slices.
 
         Args:
@@ -233,7 +233,7 @@ class LabelMaker:
             num_examples_per_instance = float('inf')
 
         for key, df in df.groupby(self.target_entity):
-            slices = self.get_slices(df=df, gap=gap, min_data=minimum_data, drop_empty=drop_empty)
+            slices = self._get_slices(df=df, gap=gap, min_data=minimum_data, drop_empty=drop_empty)
 
             for df_slice, df_metadata in slices:
                 df_metadata[self.target_entity] = key

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -278,9 +278,9 @@ class LabelMaker:
         bar_format += "Progress: {l_bar}{bar}| "
         bar_format += self.target_entity + ": {n}/{total} "
         total = len(df.groupby(self.target_entity))
-        finite = num_examples_per_instance > -1 and num_examples_per_instance != float('inf')
+        finite_examples_per_instance = num_examples_per_instance > -1 and num_examples_per_instance != float('inf')
 
-        if finite:
+        if finite_examples_per_instance:
             total *= num_examples_per_instance
 
         progress_bar = tqdm(total=total, bar_format=bar_format, disable=not verbose, file=stdout)
@@ -305,19 +305,19 @@ class LabelMaker:
                 label = {self.target_entity: key, 'cutoff_time': cutoff_time, name: label}
                 labels.append(label)
 
-            new_instance = metadata['slice'] == 1
+            first_slice_for_instance = metadata['slice'] == 1
 
-            if finite:
+            if finite_examples_per_instance:
                 progress_bar.update(n=1)
 
-                if new_instance:
+                if first_slice_for_instance:
                     instance += 1
                     n = instance - 1
                     n *= num_examples_per_instance
                     n -= progress_bar.n
                     progress_bar.update(n=n)
 
-            if not finite and new_instance:
+            if not finite_examples_per_instance and first_slice_for_instance:
                 progress_bar.update(n=1)
 
         total -= progress_bar.n

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -201,19 +201,19 @@ class LabelMaker:
 
             df_slice = df[:window_end]
 
+            if not df_slice.empty:
+                # exclude last row to avoid overlap
+                is_overlap = df_slice.index[-1] == window_end
+
+                if df_slice.index.size > 1 and is_overlap:
+                    df_slice = df_slice[:-1]
+
             if df_slice.empty and drop_empty:
                 continue
 
             metadata['window'] = (cutoff_time, window_end)
             metadata['gap'] = (cutoff_time, gap_end)
             metadata['slice'] += 1
-
-            if not df_slice.empty:
-                # exclude last row to avoid overlap
-                is_overlap = df_slice.index[-1] == window_end
-
-                if df_slice.size > 1 and is_overlap:
-                    df_slice = df_slice[:-1]
 
             yield df_slice, metadata
 

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -132,7 +132,7 @@ class LabelMaker:
         gap = to_offset(gap or self.window_size)
 
         df = df.loc[df.index.notnull()]
-        df.sort_index(inplace=True)
+        assert df.index.is_monotonic_increasing, "Please sort your dataframe chronologically before calling search"
 
         if df.empty:
             return

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -267,13 +267,6 @@ class LabelMaker:
         Returns:
             LabelTimes : Calculated labels with cutoff times.
         """
-        if self.window_size is None and gap is None:
-            more_than_one = num_examples_per_instance > 1
-            assert not more_than_one, "must specify gap if num_examples > 1 and window size = none"
-
-        self.window_size = self.window_size or len(df)
-        gap = to_offset(gap or self.window_size)
-
         bar_format = "Elapsed: {elapsed} | Remaining: {remaining} | "
         bar_format += "Progress: {l_bar}{bar}| "
         bar_format += self.target_entity + ": {n}/{total} "

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -343,7 +343,6 @@ class LabelMaker:
                     progress_bar.update(n=n)
 
             if not finite and new_instance:
-                n_instances += 1
                 progress_bar.update(n=1)
 
         total -= progress_bar.n

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -98,7 +98,7 @@ class LabelMaker:
 
         return df
 
-    def slice(self, df, num_examples_per_instance, minimum_data=None, gap=None, edges=False):
+    def slice(self, df, num_examples_per_instance, minimum_data=None, gap=None, edges=False, verbose=True):
         # assert_valid_offset(minimum_data)
         # assert_valid_offset(gap)
 
@@ -148,6 +148,9 @@ class LabelMaker:
 
                 if edges:
                     window = window, (start, stop)
+
+                if verbose:
+                    print('[{}, {}) gap'.format(start, stop), end='\n\n')
 
                 yield window
 

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -120,7 +120,8 @@ class LabelMaker:
 
         Args:
             df (DataFrame) : Data frame to generate data slices.
-            gap (str) : Time between slices. Default value is window size.
+            gap (str or int) : Time between examples. Default value is window size.
+                If an integer, search will start on the first event after the minimum data.
             min_data (int or str or Timestamp) : Threshold to cutoff data.
             drop_empty (bool) : Whether to drop empty slices. Default value is True.
 
@@ -210,7 +211,8 @@ class LabelMaker:
             df (DataFrame) : Data frame to create slices on.
             num_examples_per_instance (int) : Number of examples per unique instance of target entity.
             minimum_data (str) : Minimum data before starting search. Default value is first time of index.
-            gap (str) : Time between examples. Default value is window size.
+            gap (str or int) : Time between examples. Default value is window size.
+                If an integer, search will start on the first event after the minimum data.
             metadata (bool) : Whether to return metadata about the data slice. Default value is False.
             drop_empty (bool) : Whether to drop empty slices. Default value is True.
             verbose (bool) : Whether to print metadata about slice. Default value is False.
@@ -262,7 +264,8 @@ class LabelMaker:
             df (DataFrame) : Data frame to search and extract labels.
             num_examples_per_instance (int) : Number of examples per unique instance of target entity.
             minimum_data (str) : Minimum data before starting search. Default value is first time of index.
-            gap (str) : Time between examples.
+            gap (str or int) : Time between examples. Default value is window size.
+                If an integer, search will start on the first event after the minimum data.
             drop_empty (bool) : Whether to drop empty slices. Default value is True.
             verbose (bool) : Whether to render progress bar. Default value is True.
             *args : Positional arguments for labeling function.

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -203,10 +203,10 @@ class LabelMaker:
 
             if not df_slice.empty:
                 # exclude last row to avoid overlap
-                is_overlap = df_slice.index[-1] == window_end
+                is_overlap = df_slice.index == window_end
 
-                if df_slice.index.size > 1 and is_overlap:
-                    df_slice = df_slice[:-1]
+                if df_slice.index.size > 1 and is_overlap.any():
+                    df_slice = df_slice[~is_overlap]
 
             if df_slice.empty and drop_empty:
                 continue
@@ -393,8 +393,8 @@ class LabelMaker:
         gap = metadata.get('gap', empty)
 
         info = {
-            self.target_entity: metadata.get(self.target_entity),
             'slice': metadata['slice'],
+            self.target_entity: metadata.get(self.target_entity),
             'window': '[{}, {})'.format(*window),
             'gap': '[{}, {})'.format(*gap),
         }

--- a/composeml/label_maker.py
+++ b/composeml/label_maker.py
@@ -160,8 +160,12 @@ class LabelMaker:
                 window_end = cutoff_time + self.window_size
                 df_slice = df[:window_end]
 
+                # Pandas includes both endpoints when slicing by time.
+                # This results in the right endpoint overlapping in consecutive data slices.
+                # Resolved by making the right endpoint exclusive.
+                # https://pandas.pydata.org/pandas-docs/version/0.19/gotchas.html#endpoints-are-inclusive
+
                 if not df_slice.empty:
-                    # exclude last row to avoid overlap
                     is_overlap = df_slice.index == window_end
 
                     if df_slice.index.size > 1 and is_overlap.any():

--- a/composeml/tests/test_featuretools.py
+++ b/composeml/tests/test_featuretools.py
@@ -25,6 +25,7 @@ def labels():
         minimum_data='10min',
         num_examples_per_instance=2,
         gap='30min',
+        drop_empty=True,
         verbose=False,
     )
 

--- a/composeml/tests/test_featuretools.py
+++ b/composeml/tests/test_featuretools.py
@@ -12,6 +12,8 @@ def total_spent(df):
 @pytest.fixture
 def labels():
     df = ft.demo.load_mock_customer(return_single_table=True, random_seed=0)
+    df = df[['transaction_time', 'customer_id', 'amount']]
+    df.sort_values('transaction_time', inplace=True)
 
     lm = LabelMaker(
         target_entity='customer_id',
@@ -21,7 +23,7 @@ def labels():
     )
 
     lt = lm.search(
-        df[['transaction_time', 'customer_id', 'amount']],
+        df,
         minimum_data='10min',
         num_examples_per_instance=2,
         gap='30min',

--- a/composeml/tests/test_featuretools.py
+++ b/composeml/tests/test_featuretools.py
@@ -1,6 +1,5 @@
-import pytest
-
 import featuretools as ft
+import pytest
 
 from composeml import LabelMaker
 

--- a/composeml/tests/test_featuretools.py
+++ b/composeml/tests/test_featuretools.py
@@ -1,5 +1,6 @@
-import featuretools as ft
 import pytest
+
+import featuretools as ft
 
 from composeml import LabelMaker
 

--- a/composeml/tests/test_featuretools.py
+++ b/composeml/tests/test_featuretools.py
@@ -1,20 +1,33 @@
 import featuretools as ft
 import pytest
 
-from ..label_maker import LabelMaker
+from composeml import LabelMaker
 
 
-def my_labeling_function(df_slice):
-    label = df_slice['amount'].sum()
-    return label
+def total_spent(df):
+    total = df.amount.sum()
+    return total
 
 
 @pytest.fixture
 def labels():
-    columns = ['transaction_time', 'customer_id', 'amount']
-    df = ft.demo.load_mock_customer(return_single_table=True, random_seed=0)[columns]
-    lm = LabelMaker(target_entity='customer_id', time_index='transaction_time', labeling_function=my_labeling_function, window_size='1h')
-    lt = lm.search(df, minimum_data='10min', num_examples_per_instance=2, gap='30min')
+    df = ft.demo.load_mock_customer(return_single_table=True, random_seed=0)
+
+    lm = LabelMaker(
+        target_entity='customer_id',
+        time_index='transaction_time',
+        labeling_function=total_spent,
+        window_size='1h',
+    )
+
+    lt = lm.search(
+        df[['transaction_time', 'customer_id', 'amount']],
+        minimum_data='10min',
+        num_examples_per_instance=2,
+        gap='30min',
+        verbose=False,
+    )
+
     lt = lt.threshold(1250)
     return lt
 

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -407,23 +407,22 @@ def test_search_empty_labels(transactions):
     assert given_labels.empty
 
 
-def test_slice(transactions):
+def test_slice_overlap(transactions):
     lm = LabelMaker(
         target_entity='customer_id',
         time_index='time',
         labeling_function=total_spent,
-        window_size='2h',
+        window_size='1h',
     )
 
     slices = lm.slice(
         transactions,
         num_examples_per_instance=2,
-        minimum_data='30min',
-        gap='2h',
         metadata=True,
         verbose=True,
     )
 
     for df, metadata in slices:
-        assert isinstance(df, pd.DataFrame)
-        assert isinstance(metadata, dict)
+        start, end = metadata['window']
+        is_overlap = df.index == end
+        assert not is_overlap.any()

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -47,6 +47,7 @@ def test_search_offset_mix_0(transactions):
         num_examples_per_instance=2,
         minimum_data='30min',
         gap='2h',
+        drop_empty=True,
         verbose=False,
     )
 
@@ -359,7 +360,7 @@ def test_search_empty_labels(transactions):
     lm = LabelMaker(
         target_entity='customer_id',
         time_index='time',
-        labeling_function=lambda: None,
+        labeling_function=lambda df: None,
         window_size=2,
     )
 
@@ -388,9 +389,10 @@ def test_slice(transactions):
         num_examples_per_instance=2,
         minimum_data='30min',
         gap='2h',
-        edges=True,
+        metadata=True,
         verbose=True,
     )
 
-    for df, edges in slices:
-        assert df.index[0] == edges[0]
+    for df, metadata in slices:
+        assert isinstance(df, pd.DataFrame)
+        assert isinstance(metadata, dict)

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -1,196 +1,299 @@
 import pandas as pd
 import pytest
 
-from ..label_maker import LabelMaker
+from composeml import LabelMaker
+from composeml.tests.utils import read_csv
 
 
-def my_labeling_function(df_slice):
-    label = df_slice['amount'].sum()
-    label = label or pd.np.nan
-    return label
+@pytest.fixture
+def transactions():
+
+    data = [
+        'time,amount,customer_id',
+        '2019-01-01 08:00:00,1,0',
+        '2019-01-01 08:30:00,1,0',
+        '2019-01-01 09:00:00,1,1',
+        '2019-01-01 09:30:00,1,1',
+        '2019-01-01 10:00:00,1,1',
+        '2019-01-01 10:30:00,1,2',
+        '2019-01-01 11:00:00,1,2',
+        '2019-01-01 11:30:00,1,2',
+        '2019-01-01 12:00:00,1,2',
+        '2019-01-01 12:30:00,1,3',
+    ]
+
+    df = read_csv(data)
+    return df
 
 
-def test_search_offset_mix_0(transactions, labels):
+def total_spent(df):
+    total = df.amount.sum()
+    return total
+
+
+def test_search_offset_mix_0(transactions):
     """
     Test offset mix with window_size (absolute), minimum_data (absolute), and gap (absolute).
     """
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=my_labeling_function,
-        window_size='2min',
+        time_index='time',
+        labeling_function=total_spent,
+        window_size='2h',
     )
 
     given_labels = lm.search(
         transactions,
-        minimum_data='1min',
-        num_examples_per_instance=4,
-        gap='3min',
+        num_examples_per_instance=2,
+        minimum_data='30min',
+        gap='2h',
+        verbose=False,
     )
 
-    pd.testing.assert_frame_equal(given_labels, labels)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '0,2019-01-01 08:30:00,1',
+        '1,2019-01-01 09:30:00,2',
+        '2,2019-01-01 11:00:00,3',
+    ]
+
+    assert given_labels == labels
 
 
-def test_search_offset_mix_1(transactions, labels):
+def test_search_offset_mix_1(transactions):
     """
     Test offset mix with window_size (relative), minimum_data (absolute), and gap (absolute).
     """
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=my_labeling_function,
-        window_size=2,
+        time_index='time',
+        labeling_function=total_spent,
+        window_size=4,
     )
 
     given_labels = lm.search(
         transactions,
-        minimum_data='1min',
-        num_examples_per_instance=4,
-        gap='3min',
+        num_examples_per_instance=2,
+        minimum_data='2019-01-01 10:00:00',
+        gap='4h',
+        verbose=False,
     )
 
-    pd.testing.assert_frame_equal(given_labels, labels)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '1,2019-01-01 10:00:00,1',
+        '2,2019-01-01 10:00:00,4',
+        '3,2019-01-01 10:00:00,1',
+    ]
+
+    assert given_labels == labels
 
 
-def test_search_offset_mix_2(transactions, labels):
+def test_search_offset_mix_2(transactions):
     """
     Test offset mix with window_size (absolute), minimum_data (relative), and gap (absolute).
     """
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=my_labeling_function,
-        window_size='2min',
+        time_index='time',
+        labeling_function=total_spent,
+        window_size='30min',
     )
 
     given_labels = lm.search(
         transactions,
-        minimum_data=1,
-        num_examples_per_instance=4,
-        gap='3min',
+        num_examples_per_instance=2,
+        minimum_data=2,
+        verbose=False,
     )
 
-    pd.testing.assert_frame_equal(given_labels, labels)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '1,2019-01-01 10:00:00,1',
+        '2,2019-01-01 11:30:00,1',
+        '2,2019-01-01 12:00:00,1',
+    ]
+
+    assert given_labels == labels
 
 
-def test_search_offset_mix_3(transactions, labels):
+def test_search_offset_mix_3(transactions):
     """
     Test offset mix with window_size (absolute), minimum_data (absolute), and gap (relative).
     """
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=my_labeling_function,
-        window_size='2min',
+        time_index='time',
+        labeling_function=total_spent,
+        window_size='8h',
     )
 
     given_labels = lm.search(
         transactions,
-        minimum_data='1min',
-        num_examples_per_instance=4,
-        gap=3,
+        num_examples_per_instance=-1,
+        minimum_data='2019-01-01 08:00:00',
+        gap=1,
+        verbose=False,
     )
 
-    pd.testing.assert_frame_equal(given_labels, labels)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '0,2019-01-01 08:00:00,2',
+        '0,2019-01-01 08:30:00,1',
+        '1,2019-01-01 09:00:00,3',
+        '1,2019-01-01 09:30:00,2',
+        '1,2019-01-01 10:00:00,1',
+        '2,2019-01-01 10:30:00,4',
+        '2,2019-01-01 11:00:00,3',
+        '2,2019-01-01 11:30:00,2',
+        '2,2019-01-01 12:00:00,1',
+        '3,2019-01-01 12:30:00,1',
+    ]
+
+    assert given_labels == labels
 
 
-def test_search_offset_mix_4(transactions, labels):
+def test_search_offset_mix_4(transactions):
     """
     Test offset mix with window_size (relative), minimum_data (relative), and gap (absolute).
     """
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=my_labeling_function,
-        window_size=2,
+        time_index='time',
+        labeling_function=total_spent,
+        window_size=1,
     )
 
     given_labels = lm.search(
         transactions,
-        minimum_data=1,
-        num_examples_per_instance=4,
-        gap='3min',
+        num_examples_per_instance=2,
+        gap='30min',
+        verbose=False,
     )
 
-    pd.testing.assert_frame_equal(given_labels, labels)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '0,2019-01-01 08:00:00,1',
+        '0,2019-01-01 08:30:00,1',
+        '1,2019-01-01 09:00:00,1',
+        '1,2019-01-01 09:30:00,1',
+        '2,2019-01-01 10:30:00,1',
+        '2,2019-01-01 11:00:00,1',
+        '3,2019-01-01 12:30:00,1',
+    ]
+
+    assert given_labels == labels
 
 
-def test_search_offset_mix_5(transactions, labels):
+def test_search_offset_mix_5(transactions):
     """
     Test offset mix with window_size (relative), minimum_data (absolute), and gap (relative).
     """
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=my_labeling_function,
+        time_index='time',
+        labeling_function=total_spent,
         window_size=2,
     )
 
     given_labels = lm.search(
         transactions,
-        minimum_data='1min',
-        num_examples_per_instance=4,
-        gap=3,
+        num_examples_per_instance=2,
+        minimum_data='1h',
+        gap=2,
+        verbose=False,
     )
 
-    pd.testing.assert_frame_equal(given_labels, labels)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '1,2019-01-01 10:00:00,1',
+        '2,2019-01-01 11:30:00,2',
+    ]
+
+    assert given_labels == labels
 
 
-def test_search_offset_mix_6(transactions, labels):
+def test_search_offset_mix_6(transactions):
     """
     Test offset mix with window_size (absolute), minimum_data (relative), and gap (relative).
     """
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=my_labeling_function,
-        window_size='2min',
+        time_index='time',
+        labeling_function=total_spent,
+        window_size='1h',
     )
 
     given_labels = lm.search(
         transactions,
-        minimum_data=1,
-        num_examples_per_instance=4,
-        gap=3,
+        num_examples_per_instance=1,
+        minimum_data=3,
+        gap=1,
+        verbose=False,
     )
 
-    pd.testing.assert_frame_equal(given_labels, labels)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '2,2019-01-01 12:00:00,1',
+    ]
+
+    assert given_labels == labels
 
 
-def test_search_offset_mix_7(transactions, labels):
+def test_search_offset_mix_7(transactions):
     """
     Test offset mix with window_size (relative), minimum_data (relative), and gap (relative).
     """
-    def my_labeling_function(df_slice):
-        label = df_slice['amount'].sum()
-        return label
 
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=my_labeling_function,
-        window_size=2,
+        time_index='time',
+        labeling_function=total_spent,
+        window_size=10,
     )
 
     given_labels = lm.search(
         transactions,
-        minimum_data=1,
-        num_examples_per_instance=2,
-        gap=3,
+        num_examples_per_instance=float('inf'),
+        verbose=False,
     )
 
-    pd.testing.assert_frame_equal(given_labels, labels)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '0,2019-01-01 08:00:00,2',
+        '1,2019-01-01 09:00:00,3',
+        '2,2019-01-01 10:30:00,4',
+        '3,2019-01-01 12:30:00,1',
+    ]
+
+    assert given_labels == labels
 
 
 def test_search_offset_negative_0(transactions):
-    match = 'negative offset'
-
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=None,
+        time_index='time',
+        labeling_function=lambda: None,
         window_size=2,
     )
+
+    match = 'must be greater than zero'
 
     with pytest.raises(AssertionError, match=match):
         lm.search(
@@ -198,18 +301,19 @@ def test_search_offset_negative_0(transactions):
             num_examples_per_instance=2,
             minimum_data=-1,
             gap=-1,
+            verbose=False,
         )
 
 
 def test_search_offset_negative_1(transactions):
-    match = 'negative offset'
-
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=None,
+        time_index='time',
+        labeling_function=lambda: None,
         window_size=2,
     )
+
+    match = 'must be greater than zero'
 
     with pytest.raises(AssertionError, match=match):
         lm.search(
@@ -217,37 +321,49 @@ def test_search_offset_negative_1(transactions):
             num_examples_per_instance=2,
             minimum_data='-1h',
             gap='-1h',
+            verbose=False,
         )
 
 
-def test_search_offset_invalid_type(transactions):
-    match = 'invalid offset type'
+def test_invalid_offset(transactions):
+    match = 'invalid offset'
 
+    with pytest.raises(AssertionError, match=match):
+        LabelMaker(
+            target_entity='customer_id',
+            time_index='time',
+            labeling_function=lambda: None,
+            window_size={},
+        )
+
+
+def test_invalid_threshold(transactions):
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=None,
+        time_index='time',
+        labeling_function=lambda: None,
         window_size=2,
     )
 
-    with pytest.raises(TypeError, match=match):
+    match = 'invalid threshold'
+
+    with pytest.raises(ValueError, match=match):
         lm.search(
             transactions,
             num_examples_per_instance=2,
-            minimum_data=[],
-            gap=[],
+            minimum_data=' ',
         )
 
 
 def test_search_empty_labels(transactions):
-    transactions['transaction_time'] = pd.NaT
-
     lm = LabelMaker(
         target_entity='customer_id',
-        time_index='transaction_time',
-        labeling_function=type(None),
+        time_index='time',
+        labeling_function=lambda: None,
         window_size=2,
     )
+
+    transactions = transactions.assign(time=pd.NaT)
 
     given_labels = lm.search(
         transactions,
@@ -257,3 +373,24 @@ def test_search_empty_labels(transactions):
     )
 
     assert given_labels.empty
+
+
+def test_slice(transactions):
+    lm = LabelMaker(
+        target_entity='customer_id',
+        time_index='time',
+        labeling_function=total_spent,
+        window_size='2h',
+    )
+
+    slices = lm.slice(
+        transactions,
+        num_examples_per_instance=2,
+        minimum_data='30min',
+        gap='2h',
+        edges=True,
+        verbose=True,
+    )
+
+    for df, edges in slices:
+        assert df.index[0] == edges[0]

--- a/composeml/tests/test_label_maker.py
+++ b/composeml/tests/test_label_maker.py
@@ -31,6 +31,23 @@ def total_spent(df):
     return total
 
 
+def test_search_default(transactions):
+    lm = LabelMaker(target_entity='customer_id', time_index='time', labeling_function=total_spent)
+
+    given_labels = lm.search(transactions, num_examples_per_instance=1, verbose=False)
+    given_labels = given_labels.to_csv(index=False).splitlines()
+
+    labels = [
+        'customer_id,cutoff_time,total_spent',
+        '0,2019-01-01 08:00:00,2',
+        '1,2019-01-01 09:00:00,3',
+        '2,2019-01-01 10:30:00,4',
+        '3,2019-01-01 12:30:00,1',
+    ]
+
+    assert given_labels == labels
+
+
 def test_search_offset_mix_0(transactions):
     """
     Test offset mix with window_size (absolute), minimum_data (absolute), and gap (absolute).
@@ -354,6 +371,20 @@ def test_invalid_threshold(transactions):
             num_examples_per_instance=2,
             minimum_data=' ',
         )
+
+
+def test_search_invalid_n_examples(transactions):
+    lm = LabelMaker(
+        target_entity='customer_id',
+        time_index='time',
+        labeling_function=total_spent,
+    )
+
+    with pytest.raises(AssertionError, match='must specify gap'):
+        next(lm.slice(transactions, num_examples_per_instance=2, verbose=False))
+
+    with pytest.raises(AssertionError, match='must specify gap'):
+        lm.search(transactions, num_examples_per_instance=2, verbose=False)
 
 
 def test_search_empty_labels(transactions):

--- a/composeml/tests/utils.py
+++ b/composeml/tests/utils.py
@@ -1,0 +1,13 @@
+from io import StringIO
+
+import pandas as pd
+
+
+def read_csv(csv):
+    if isinstance(csv, list):
+        csv = '\n'.join(csv)
+
+    with StringIO(csv) as file:
+        df = pd.read_csv(file)
+
+    return df

--- a/composeml/utils.py
+++ b/composeml/utils.py
@@ -1,0 +1,16 @@
+def is_type(type, string):
+    """Return whether the string can be interpreted as a type.
+
+    Args:
+        type (type) : Type to apply on string.
+        string (str) : String to check if can be type.
+
+    Returns:
+        bool : Whether string can be type.
+    """
+    try:
+        type(string)
+        return True
+
+    except ValueError:
+        return False

--- a/composeml/utils.py
+++ b/composeml/utils.py
@@ -1,4 +1,4 @@
-def is_type(type, string):
+def can_be_type(type, string):
     """Return whether the string can be interpreted as a type.
 
     Args:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 [flake8]
 exclude = docs/*
-ignore = E501,E701,E999,W504
+ignore = E501,E701,W504
 [metadata]
 description-file = README.md
 [aliases]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 [flake8]
 exclude = docs/*
-ignore = E501,W504
+ignore = E501,E701,W504
 [metadata]
 description-file = README.md
 [aliases]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning
 [flake8]
 exclude = docs/*
-ignore = E501,E701,W504
+ignore = E501,E701,E999,W504
 [metadata]
 description-file = README.md
 [aliases]


### PR DESCRIPTION
# Slice Generator
Users can inspect data or debug labeling function one slice at a time.
## Example
```
     transaction_time  customer_id  amount
0 2014-01-01 00:00:00            2  127.64
1 2014-01-01 00:09:45            2   57.39
2 2014-01-01 00:14:05            2   69.45
3 2014-01-01 02:33:50            2  123.19
4 2014-01-01 02:37:05            2   64.47
5 2014-01-01 02:41:25            2   52.28
6 2014-01-01 02:44:40            2   50.45
7 2014-01-01 03:42:05            2   47.39
8 2014-01-01 03:48:35            2  146.81
9 2014-01-01 03:55:05            2  135.48
```
### Construct Label Maker
```python
lm = LabelMaker(
    target_entity='customer_id',
    time_index='transaction_time',
    labeling_function=total_spent,
    window_size='1h',
)
```
### Generate Slices
Slices are returned as a generator. A user can get extra information such as the intervals of the window and gap for each slice by setting verbose to `True`. Additionally, `window_size`, `gap`, and `minimum_data` are integrated with [offset aliases](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases) in pandas. This gives the user more options when setting these parameters.
```python
slices = lm.slice(
    df,
    minimum_data='2014-01-01 00:00:00',
    num_examples_per_instance=1,
    verbose=True,
)

next(slices)
```
```
customer_id                                             1
slice                                                   1
window         [2014-01-01 00:00:00, 2014-01-01 01:00:00)
gap            [2014-01-01 00:00:00, 2014-01-01 01:00:00)


                     customer_id  amount
transaction_time
2014-01-01 00:44:25            1   21.35
2014-01-01 00:45:30            1  108.11
2014-01-01 00:46:35            1  112.53
2014-01-01 00:47:40            1    6.29
2014-01-01 00:48:45            1   47.95
2014-01-01 00:49:50            1  124.29
2014-01-01 00:50:55            1   98.16
2014-01-01 00:52:00            1   31.37
2014-01-01 00:53:05            1   82.88
2014-01-01 00:54:10            1   37.50
2014-01-01 00:55:15            1   19.35
2014-01-01 00:56:20            1   46.92
2014-01-01 00:57:25            1   20.79
2014-01-01 00:58:30            1   43.59
2014-01-01 00:59:35            1   69.98
```
### Labeling Function
```python
def total_spent(df):
    total = df.amount.sum()
    return total
```
### Using Specific Cutoff Times
Cutoff times can easily be set at specific times (i.e. first of the week, first of the month, etc.) by setting `minimum_data` directly as the first cutoff time.

```python
lt = lm.search(
    df,
    minimum_data='2014-01-01 00:00:00',
    num_examples_per_instance=2,
    gap='1h',
)
```
```
    customer_id         cutoff_time  total_spent
id
0             1 2014-01-01 00:00:00       871.06
1             1 2014-01-01 01:00:00      2009.47
2             2 2014-01-01 00:00:00      1229.01
3             2 2014-01-01 02:00:00      1320.64
4             3 2014-01-01 01:00:00       941.87
5             3 2014-01-01 04:00:00       944.85
6             4 2014-01-01 00:00:00      1329.00
7             4 2014-01-01 01:00:00      1056.97
8             5 2014-01-01 00:00:00       746.96
9             5 2014-01-01 04:00:00       900.13
```

Tests have also been updated for the label maker. Closes #43 