### PR TITLE
Update Sample

### DIFF
--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -333,26 +333,28 @@ class LabelTimes(pd.DataFrame):
             return sample
 
         if isinstance(n, dict):
-            sample_per_label = self.head(0)
+            sample_per_label = []
             for label, n, in n.items():
                 label = self[self[self.name] == label]
                 sample = label.sample(n=n, random_state=random_state)
-                sample_per_label = sample_per_label.append(sample)
+                sample_per_label.append(sample)
 
-            return sample_per_label
+            sample = pd.concat(sample_per_label, axis=0, sort=False)
+            return sample
 
         if isinstance(frac, float):
             sample = super().sample(frac=frac, random_state=random_state)
             return sample
 
         if isinstance(frac, dict):
-            sample_per_label = self.head(0)
+            sample_per_label = []
             for label, frac, in frac.items():
                 label = self[self[self.name] == label]
                 sample = label.sample(frac=frac, random_state=random_state)
-                sample_per_label = sample_per_label.append(sample)
+                sample_per_label.append(sample)
 
-            return sample_per_label
+            sample = pd.concat(sample_per_label, axis=0, sort=False)
+            return sample
 
     def infer_type(self):
         """Infer label type.

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -46,9 +46,9 @@ class LabelTimes(pd.DataFrame):
         """
         if method == 'concat':
             other = other.objs[0]
-            for name in self._metadata:
-                metadata = getattr(other, name, None)
-                setattr(self, name, metadata)
+            for key in self._metadata:
+                value = getattr(other, key, None)
+                setattr(self, key, value)
 
             return self
 

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -264,7 +264,7 @@ class LabelTimes(pd.DataFrame):
         label_times.settings['label_type'] = 'discrete'
         return label_times
 
-    def sample(self, n=None, frac=None, random_state=None):
+    def sample(self, n=None, frac=None, random_state=None, replace=False):
         """
         Return a random sample of labels.
 
@@ -274,6 +274,7 @@ class LabelTimes(pd.DataFrame):
             frac (float or dict) : Sample fraction of labels. A dictionary returns
                 the sample fraction to each label. Cannot be used with n.
             random_state (int) : Seed for the random number generator.
+            replace (bool) : Sample with or without replacement. Default value is False.
 
         Returns:
             LabelTimes : Random sample of labels.
@@ -329,28 +330,28 @@ class LabelTimes(pd.DataFrame):
             4      B
         """ # noqa
         if isinstance(n, int):
-            sample = super().sample(n=n, random_state=random_state)
+            sample = super().sample(n=n, random_state=random_state, replace=replace)
             return sample
 
         if isinstance(n, dict):
             sample_per_label = []
             for label, n, in n.items():
                 label = self[self[self.name] == label]
-                sample = label.sample(n=n, random_state=random_state)
+                sample = label.sample(n=n, random_state=random_state, replace=replace)
                 sample_per_label.append(sample)
 
             sample = pd.concat(sample_per_label, axis=0, sort=False)
             return sample
 
         if isinstance(frac, float):
-            sample = super().sample(frac=frac, random_state=random_state)
+            sample = super().sample(frac=frac, random_state=random_state, replace=replace)
             return sample
 
         if isinstance(frac, dict):
             sample_per_label = []
             for label, frac, in frac.items():
                 label = self[self[self.name] == label]
-                sample = label.sample(frac=frac, random_state=random_state)
+                sample = label.sample(frac=frac, random_state=random_state, replace=replace)
                 sample_per_label.append(sample)
 
             sample = pd.concat(sample_per_label, axis=0, sort=False)

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -321,8 +321,11 @@ class LabelTimes(pd.DataFrame):
                 sample = label.sample(n=n, random_state=random_state)
                 sample_per_label.append(sample)
 
-            labels = pd.concat(sample_per_label, axis=0, sort=False)
-            return labels
+            sample = pd.concat(sample_per_label, axis=0, sort=False)
+            sample.name = self.name
+            sample.settings = self.settings
+            sample.transforms = self.transforms
+            return sample
 
         if isinstance(frac, float):
             sample = super().sample(frac=frac, random_state=random_state)
@@ -335,8 +338,11 @@ class LabelTimes(pd.DataFrame):
                 sample = label.sample(frac=frac, random_state=random_state)
                 sample_per_label.append(sample)
 
-            labels = pd.concat(sample_per_label, axis=0, sort=False)
-            return labels
+            sample = pd.concat(sample_per_label, axis=0, sort=False)
+            sample.name = self.name
+            sample.settings = self.settings
+            sample.transforms = self.transforms
+            return sample
 
     def infer_type(self):
         """Infer label type.

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -42,7 +42,7 @@ class LabelTimes(pd.DataFrame):
 
         Args:
             other (LabelTimes) : The label times from which to get the attributes from.
-            method (str) : A passed method name (optional). For taking different types of propagation actions based on this.
+            method (str) : A passed method name for optionally taking different types of propagation actions based on this value.
         """
         if method == 'concat':
             other = other.objs[0]

--- a/composeml/tests/test_label_transforms/test_sample.py
+++ b/composeml/tests/test_label_transforms/test_sample.py
@@ -59,3 +59,19 @@ def test_sample_frac_dict(labels):
     ]
 
     assert given_answer == answer
+
+
+def test_sample_metadata_n_dict(labels):
+    n = {True: 2, False: 2}
+    sample = labels.sample(n=n)
+    assert sample.name == labels.name
+    assert sample.settings == labels.settings
+    assert sample.transforms == labels.transforms
+
+
+def test_sample_metadata_frac_dict(labels):
+    frac = {True: .5, False: .5}
+    sample = labels.sample(frac=frac)
+    assert sample.name == labels.name
+    assert sample.settings == labels.settings
+    assert sample.transforms == labels.transforms

--- a/composeml/tests/test_label_transforms/test_sample.py
+++ b/composeml/tests/test_label_transforms/test_sample.py
@@ -75,3 +75,10 @@ def test_sample_metadata_frac_dict(labels):
     assert sample.name == labels.name
     assert sample.settings == labels.settings
     assert sample.transforms == labels.transforms
+
+
+def test_sample_with_replacement(labels):
+    assert labels.shape[0] < 20
+    n = {True: 10, False: 10}
+    sample = labels.sample(n=n, replace=True)
+    assert sample.shape[0] == 20


### PR DESCRIPTION
When sampling labels using a dictionary, the labels lose values for name, settings, and transforms. This PR fixes by reassigning attributes after sampling.