### PR TITLE
Move featuretools to test requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,3 @@ isort==4.3.4
 jupyter==1.0.0
 nbconvert==5.5.0
 nbsphinx==0.4.2
-featuretools>=0.9.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ fastparquet>=0.1.6
 pytest==4.4.1
 pytest-xdist==1.26.1
 pytest-cov==2.6.1
+featuretools>=0.9.0


### PR DESCRIPTION
Featuretools is required to run the tests but is not in the main requirements or test requirements file