### PR TITLE
Pass kwargs through for overridden pandas methods

### DIFF
--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -241,6 +241,9 @@ class LabelTimes(pd.DataFrame):
         """
         Makes a copy of this object.
 
+        Args:
+            **kwargs: Keyword arguments to pass to underlying pandas.DataFrame.copy method
+
         Returns:
             LabelTimes : Copy of label times.
         """
@@ -528,6 +531,7 @@ class LabelTimes(pd.DataFrame):
 
         Args:
             other (LabelTimes) : Other label time object for comparison.
+            **kwargs: Keyword arguments to pass to underlying pandas.DataFrame.equals method
 
         Returns:
             bool : Whether label time objects are the same.
@@ -575,6 +579,7 @@ class LabelTimes(pd.DataFrame):
             path (str) : Location on disk to write to (will be created as a directory).
             filename (str) : Filename for label times. Default value is `label_times.csv`.
             save_settings (bool) : Whether to save the settings used to make the label times.
+            **kwargs: Keyword arguments to pass to underlying pandas.DataFrame.to_csv method
         """
         os.makedirs(path, exist_ok=True)
         file = os.path.join(path, filename)
@@ -590,6 +595,7 @@ class LabelTimes(pd.DataFrame):
             path (str) : Location on disk to write to (will be created as a directory).
             filename (str) : Filename for label times. Default value is `label_times.parquet`.
             save_settings (bool) : Whether to save the settings used to make the label times.
+            **kwargs: Keyword arguments to pass to underlying pandas.DataFrame.to_parquet method
         """
         os.makedirs(path, exist_ok=True)
         file = os.path.join(path, filename)
@@ -598,13 +604,14 @@ class LabelTimes(pd.DataFrame):
         if save_settings:
             self._save_settings(path)
 
-    def to_pickle(self, path, filename='label_times.pickle', save_settings=True):
+    def to_pickle(self, path, filename='label_times.pickle', save_settings=True, **kwargs):
         """Write label times in pickle format to disk.
 
         Args:
             path (str) : Location on disk to write to (will be created as a directory).
             filename (str) : Filename for label times. Default value is `label_times.pickle`.
             save_settings (bool) : Whether to save the settings used to make the label times.
+            **kwargs: Keyword arguments to pass to underlying pandas.DataFrame.to_pickle method
         """
         os.makedirs(path, exist_ok=True)
         file = os.path.join(path, filename)

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -237,14 +237,14 @@ class LabelTimes(pd.DataFrame):
         if len(transforms) == 0:
             print('No transforms applied', end='\n\n')
 
-    def copy(self):
+    def copy(self, **kwargs):
         """
         Makes a copy of this object.
 
         Returns:
             LabelTimes : Copy of label times.
         """
-        label_times = super().copy()
+        label_times = super().copy(**kwargs)
         label_times.settings = self.settings.copy()
         label_times.transforms = self.transforms.copy()
         return label_times
@@ -523,7 +523,7 @@ class LabelTimes(pd.DataFrame):
 
         return 'continuous'
 
-    def equals(self, other):
+    def equals(self, other, **kwargs):
         """Determines if two label time objects are the same.
 
         Args:
@@ -532,7 +532,7 @@ class LabelTimes(pd.DataFrame):
         Returns:
             bool : Whether label time objects are the same.
         """
-        return super().equals(other) and self.settings == other.settings
+        return super().equals(other, **kwargs) and self.settings == other.settings
 
     def _load_settings(self, path):
         """Read the settings in json format from disk.
@@ -568,7 +568,7 @@ class LabelTimes(pd.DataFrame):
             json.dump(self.settings, file)
             del self.settings['dtypes']
 
-    def to_csv(self, path, filename='label_times.csv', save_settings=True):
+    def to_csv(self, path, filename='label_times.csv', save_settings=True, **kwargs):
         """Write label times in csv format to disk.
 
         Args:
@@ -578,12 +578,12 @@ class LabelTimes(pd.DataFrame):
         """
         os.makedirs(path, exist_ok=True)
         file = os.path.join(path, filename)
-        super().to_csv(file)
+        super().to_csv(file, **kwargs)
 
         if save_settings:
             self._save_settings(path)
 
-    def to_parquet(self, path, filename='label_times.parquet', save_settings=True):
+    def to_parquet(self, path, filename='label_times.parquet', save_settings=True, **kwargs):
         """Write label times in parquet format to disk.
 
         Args:
@@ -593,7 +593,7 @@ class LabelTimes(pd.DataFrame):
         """
         os.makedirs(path, exist_ok=True)
         file = os.path.join(path, filename)
-        super().to_parquet(file, compression=None, engine='auto')
+        super().to_parquet(file, compression=None, engine='auto', **kwargs)
 
         if save_settings:
             self._save_settings(path)

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -615,7 +615,7 @@ class LabelTimes(pd.DataFrame):
         """
         os.makedirs(path, exist_ok=True)
         file = os.path.join(path, filename)
-        super().to_pickle(file)
+        super().to_pickle(file, **kwargs)
 
         if save_settings:
             self._save_settings(path)


### PR DESCRIPTION
For Pandas DataFrame methods that LabelTimes overrides, passes extra keyword arguments to the underlying Pandas method

Closes #117