### PR TITLE
Update Tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,8 @@ jobs:
                 source env/bin/activate
                 cd package
                 make unit-tests ADDOPTS="--cov=composeml" -f ../Makefile
-                codecov
+                cd ..
+                codecov --file package/.coverage
 
       - unless:
           condition: << parameters.codecov >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,7 @@ jobs:
                 source env/bin/activate
                 cd package
                 make unit-tests ADDOPTS="--cov=composeml" -f ../Makefile
-                cd ..
-                codecov --file package/.coverage
+                codecov --root ..
 
       - unless:
           condition: << parameters.codecov >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,13 @@ executors:
 commands:
   build_package:
     steps:
-      - run: |
-          python setup.py sdist
-          PACKAGE=$(python setup.py --fullname)
-          tar -zxvf "dist/${PACKAGE}.tar.gz"
-          mv $PACKAGE package
+      - run:
+          name: "Build the source distribution to install the package."
+          command: |
+            python setup.py sdist
+            PACKAGE=$(python setup.py --fullname)
+            tar -zxvf "dist/${PACKAGE}.tar.gz"
+            mv $PACKAGE package
 
   installation:
     parameters:
@@ -29,7 +31,7 @@ commands:
       - checkout
       - build_package
       - run:
-          name: "Create virtual environment and install requirements."
+          name: "Create a virtual environment and install the requirements to use the package."
           command: |
             virtualenv env -q
             source env/bin/activate
@@ -40,7 +42,7 @@ commands:
           condition: << parameters.test_requirements >>
           steps:
             - run:
-                name: "Install test requirements."
+                name: "Install the requirements to test the package."
                 command: |
                   source env/bin/activate
                   pip install -r package/dev-requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ commands:
 
 jobs:
   lint_tests:
+    working_directory: ~/composeml
     parameters:
       python_version:
         type: string
@@ -58,6 +59,7 @@ jobs:
             make lint-tests
 
   unit_tests:
+    working_directory: ~/composeml
     parameters:
       python_version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ commands:
       - run:
           name: "Create virtual environment and install requirements."
           command: |
-            virtualenv circleci -q
-            source circleci/bin/activate
+            virtualenv python -q
+            source python/bin/activate
             pip config --site set global.progress_bar off
             pip install .
 
@@ -33,7 +33,7 @@ commands:
             - run:
                 name: "Install test requirements."
                 command: |
-                  source circleci/bin/activate
+                  source python/bin/activate
                   pip install -r dev-requirements.txt
 
 jobs:
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: "Run lint tests."
           command: |
-            source circleci/bin/activate
+            source python/bin/activate
             make lint-tests
 
   unit_tests:
@@ -80,16 +80,15 @@ jobs:
           condition: << parameters.codecov >>
           steps:
             - run: |
-                source circleci/bin/activate
+                source python/bin/activate
                 make unit-tests ADDOPTS="--cov=composeml"
                 codecov
 
       - unless:
-          name: "Run unit tests."
           condition: << parameters.codecov >>
           steps:
             - run: |
-                source circleci/bin/activate
+                source python/bin/activate
                 make unit-tests
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,48 +1,121 @@
 version: 2.1
 
+executors:
+  python:
+    parameters:
+      version:
+        type: string
+        default: "3.7"
+
+    docker:
+      - image: circleci/python:<< parameters.version >>
+
+commands:
+  installation:
+    parameters:
+      test_requirements:
+        type: boolean
+        default: false
+
+    steps:
+      - checkout
+      - run:
+          name: "Install requirements in a virtual environment."
+          command: |
+            virtualenv python -q
+            source python/bin/activate
+            pip config --site set global.progress_bar off
+            pip install .
+
+      - when:
+          condition: << parameters.test_requirements >>
+          steps:
+            - run:
+                name: "Install test requirements."
+                command: |
+                  source python/bin/activate
+                  pip install -r test-requirements.txt
+
 jobs:
-  test_python:
+  lint_tests:
     parameters:
       python_version:
         type: string
         default: "3.7"
+
+    executor:
+      name: python
+      version: << parameters.python_version >>
+
+    steps:
+      - installation:
+          test_requirements: true
+
+      - run:
+          name: "Run lint tests."
+          command: |
+            source python/bin/activate
+            make lint-tests
+
+  unit_tests:
+    parameters:
+      python_version:
+        type: string
+        default: "3.7"
+
       codecov:
         type: boolean
         default: false
-    working_directory: ~/compose
-    docker:
-        - image: circleci/python:<< parameters.python_version >>
+
+    executor:
+      name: python
+      version: << parameters.python_version >>
+
     steps:
-      - checkout
-      - run: |
-          virtualenv test_python -q
-          source test_python/bin/activate
-          make installdeps
-      - run: |
-          source test_python/bin/activate
-          make lint
-      - run: |
-          source test_python/bin/activate
-          coverage erase
-          make test
+      - installation:
+          test_requirements: true
+
       - when:
+          name: "Run unit tests with code coverage."
           condition: << parameters.codecov >>
           steps:
             - run: |
-                source test_python/bin/activate
+                source python/bin/activate
+                make unit-tests ADDOPTS="--cov=composeml"
                 codecov
+
+      - unless:
+          name: "Run unit tests."
+          condition: << parameters.codecov >>
+          steps:
+            - run: |
+                source python/bin/activate
+                make unit-tests
 
 workflows:
   version: 2
-  test_all_python_versions:
+  "Integration Tests":
     jobs:
-      - test_python:
-          name: "python 3.5"
-          python_version: "3.5"
-      - test_python:
-          name: "python 3.6"
+      - lint_tests:
+          name: "Lint Tests - Python 3.6"
           python_version: "3.6"
-      - test_python:
-          name: "python 3.7"
+
+      - lint_tests:
+          name: "Lint Tests - Python 3.7"
           python_version: "3.7"
-          codecov: true
+
+      - lint_tests:
+          name: "Lint Tests - Python 3.8"
+          python_version: "3.8"
+
+      - unit_tests:
+          name: "Unit Tests - Python 3.6"
+          python_version: "3.6"
+
+      - unit_tests:
+          name: "Unit Tests - Python 3.7"
+          python_version: "3.7"
+
+      - unit_tests:
+          name: "Unit Tests - Python 3.8"
+          python_version: "3.8"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,14 @@ executors:
       - image: circleci/python:<< parameters.version >>
 
 commands:
+  build_package:
+    steps:
+      - run: |
+          python setup.py sdist
+          PACKAGE=$(python setup.py --fullname)
+          tar -zxvf "dist/${PACKAGE}.tar.gz"
+          mv $PACKAGE package
+
   installation:
     parameters:
       test_requirements:
@@ -19,13 +27,14 @@ commands:
 
     steps:
       - checkout
+      - build_package
       - run:
           name: "Create virtual environment and install requirements."
           command: |
-            virtualenv python -q
-            source python/bin/activate
+            virtualenv env -q
+            source env/bin/activate
             pip config --site set global.progress_bar off
-            pip install .
+            pip install package/
 
       - when:
           condition: << parameters.test_requirements >>
@@ -33,8 +42,8 @@ commands:
             - run:
                 name: "Install test requirements."
                 command: |
-                  source python/bin/activate
-                  pip install -r dev-requirements.txt
+                  source env/bin/activate
+                  pip install -r package/dev-requirements.txt
 
 jobs:
   lint_tests:
@@ -54,7 +63,7 @@ jobs:
       - run:
           name: "Run lint tests."
           command: |
-            source python/bin/activate
+            source env/bin/activate
             make lint-tests
 
   unit_tests:
@@ -80,7 +89,7 @@ jobs:
           condition: << parameters.codecov >>
           steps:
             - run: |
-                source python/bin/activate
+                source env/bin/activate
                 make unit-tests ADDOPTS="--cov=composeml"
                 codecov
 
@@ -88,7 +97,7 @@ jobs:
           condition: << parameters.codecov >>
           steps:
             - run: |
-                source python/bin/activate
+                source env/bin/activate
                 make unit-tests
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ commands:
       - run:
           name: "Install requirements in a virtual environment."
           command: |
-            virtualenv python -q
-            source python/bin/activate
+            virtualenv circleci -q
+            source circleci/bin/activate
             pip config --site set global.progress_bar off
             pip install .
 
@@ -33,12 +33,11 @@ commands:
             - run:
                 name: "Install test requirements."
                 command: |
-                  source python/bin/activate
+                  source circleci/bin/activate
                   pip install -r test-requirements.txt
 
 jobs:
   lint_tests:
-    working_directory: ~/composeml
     parameters:
       python_version:
         type: string
@@ -55,11 +54,10 @@ jobs:
       - run:
           name: "Run lint tests."
           command: |
-            source python/bin/activate
+            source circleci/bin/activate
             make lint-tests
 
   unit_tests:
-    working_directory: ~/composeml
     parameters:
       python_version:
         type: string
@@ -82,7 +80,7 @@ jobs:
           condition: << parameters.codecov >>
           steps:
             - run: |
-                source python/bin/activate
+                source circleci/bin/activate
                 make unit-tests ADDOPTS="--cov=composeml"
                 codecov
 
@@ -91,7 +89,7 @@ jobs:
           condition: << parameters.codecov >>
           steps:
             - run: |
-                source python/bin/activate
+                source circleci/bin/activate
                 make unit-tests
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
     steps:
       - checkout
       - run:
-          name: "Install requirements in a virtual environment."
+          name: "Create virtual environment and install requirements."
           command: |
             virtualenv circleci -q
             source circleci/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
                 name: "Install test requirements."
                 command: |
                   source circleci/bin/activate
-                  pip install -r test-requirements.txt
+                  pip install -r dev-requirements.txt
 
 jobs:
   lint_tests:
@@ -119,3 +119,4 @@ workflows:
       - unit_tests:
           name: "Unit Tests - Python 3.8"
           python_version: "3.8"
+          codecov: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,8 @@ jobs:
           name: "Run lint tests."
           command: |
             source env/bin/activate
-            make lint-tests
+            cd package
+            make lint-tests -f ../Makefile
 
   unit_tests:
     parameters:
@@ -92,7 +93,8 @@ jobs:
           steps:
             - run: |
                 source env/bin/activate
-                make unit-tests ADDOPTS="--cov=composeml"
+                cd package
+                make unit-tests ADDOPTS="--cov=composeml" -f ../Makefile
                 codecov
 
       - unless:
@@ -100,7 +102,8 @@ jobs:
           steps:
             - run: |
                 source env/bin/activate
-                make unit-tests
+                cd package
+                make unit-tests -f ../Makefile
 
 workflows:
   version: 2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.txt
 include LICENSE
 include README.md
+include composeml/demos/*.csv
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ lint-tests:
 	isort --check-only --recursive composeml
 
 unit-tests:
-	pytest --cache-clear --show-capture=stderr -vv ${ADDOPTS}
+	pytest composeml/tests --cache-clear --show-capture=stderr -vv ${ADDOPTS}

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,11 @@
-.PHONY: clean
-clean:
-	find . -name '*.pyo' -delete
-	find . -name '*.pyc' -delete
-	find . -name __pycache__ -delete
-	find . -name '*~' -delete
-
-.PHONY: lint
-lint:
-	flake8 composeml && isort --check-only --recursive composeml
-
-.PHONY: lint-fix
 lint-fix:
-	autopep8 --in-place --recursive --max-line-length=100 --select="E225,E303,E302,E203,E128,E231,E251,E271,E127,E126,E301,W291,W293,E226,E306,E221" composeml
+	select="E225,E303,E302,E203,E128,E231,E251,E271,E127,E126,E301,W291,W293,E226,E306,E221"
+	autopep8 --in-place --recursive --max-line-length=100 --select=${select} composeml
 	isort --recursive composeml
 
-.PHONY: test
-test:
-	pytest composeml/tests --cov=composeml
+lint-tests:
+	flake8 composeml
+	isort --check-only --recursive composeml
 
-.PHONY: installdeps
-installdeps:
-	pip install --upgrade pip -q
-	pip install -e . -q
-	pip install -r dev-requirements.txt -q
+unit-tests:
+	pytest --cache-clear --show-capture=stderr -vv ${ADDOPTS}

--- a/composeml/demos/__init__.py
+++ b/composeml/demos/__init__.py
@@ -1,5 +1,6 @@
-import pandas as pd
 import os
+
+import pandas as pd
 
 DATA = os.path.join(os.path.dirname(__file__))
 

--- a/composeml/label_times.py
+++ b/composeml/label_times.py
@@ -360,7 +360,7 @@ class LabelTimes(pd.DataFrame):
             customer_id                             1                    1
             cutoff_time           2014-01-01 00:45:00  2014-01-01 00:48:00
             my_labeling_function                 high                  low
-        """ # noqa
+        """  # noqa
         label_times = self.copy()
         values = label_times[self.name].values
 
@@ -493,7 +493,7 @@ class LabelTimes(pd.DataFrame):
             4      B
             5      A
             6      A
-        """ # noqa
+        """  # noqa
         settings = {
             'transform': 'sample',
             'n': n,

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,4 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     packages=find_packages(),
-    package_data={'composeml': ['demos/*.csv']},
-    include_package_data=True,
 )


### PR DESCRIPTION
This closes #127 by removing tests that use Python 3.5 and adding Python 3.8 in CircleCI.