### PR TITLE
v0.2.0

### DIFF
--- a/composeml/__init__.py
+++ b/composeml/__init__.py
@@ -3,4 +3,4 @@ from . import demos
 from .label_maker import LabelMaker
 from .label_times import LabelTimes, read_csv, read_parquet, read_pickle
 
-__version__ = '0.1.8'
+__version__ = '0.2.0'

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,12 +4,12 @@ Changelog
 
 **v0.2.0** April 23, 2020
     * Changes
+        * Dropped Supported for Python 3.5 (:pr:`128`)
         * Rename LabelTimes.name to LabelTimes.label_name (:pr:`126`)
         * Support keywords arguments in Pandas methods. (:pr:`121`)
     * Documentation Changes
         * Improved data download in Predict Next Purchase (:pr:`76`)
     * Testing Changes
-        * Removed tests that use Python 3.5 in CirlceCI (:pr:`128`)
         * Added tests that use Python 3.8 in CirlceCI (:pr:`128`)
 
 **Breaking Changes**

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 **v0.2.0** April 23, 2020
     * Changes
-        * Dropped Supported for Python 3.5 (:pr:`128`)
+        * Dropped Support for Python 3.5 (:pr:`128`)
         * Rename LabelTimes.name to LabelTimes.label_name (:pr:`126`)
         * Support keyword arguments in Pandas methods. (:pr:`121`)
     * Documentation Changes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,13 +1,19 @@
 =========
 Changelog
 =========
-**Future Release**
+
+**v0.2.0** April 23, 2020
     * Changes
         * Rename LabelTimes.name to LabelTimes.label_name (:pr:`126`)
+        * Support keywords arguments in Pandas methods. (:pr:`121`)
+    * Documentation Changes
+        * Improved data download in Predict Next Purchase (:pr:`76`)
+    * Testing Changes
+        * Removed tests that use Python 3.5 in CirlceCI (:pr:`128`)
+        * Added tests that use Python 3.8 in CirlceCI (:pr:`128`)
 
 **Breaking Changes**
-
-* ``LabelTimes.name`` has been renamed to ``LabelTimes.label_name``
+    * ``LabelTimes.name`` has been renamed to ``LabelTimes.label_name``
 
 **v0.1.8** March 11, 2020
     * Fixes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
     * Changes
         * Dropped Supported for Python 3.5 (:pr:`128`)
         * Rename LabelTimes.name to LabelTimes.label_name (:pr:`126`)
-        * Support keywords arguments in Pandas methods. (:pr:`121`)
+        * Support keyword arguments in Pandas methods. (:pr:`121`)
     * Documentation Changes
         * Improved data download in Predict Next Purchase (:pr:`76`)
     * Testing Changes

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,6 +2,6 @@
 Install
 =======
 
-Compose is available for Python >= 3.5. To install, use :code:`pip` by running the following commmand::
+In Python 3.6 or later, Compose can be installed by running the following commmand:
 
     pip install composeml

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='composeml',
-    version='0.1.8',
+    version='0.2.0',
     author='Feature Labs, Inc.',
     author_email='support@featurelabs.com',
     license='BSD 3-clause',

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,5 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     packages=find_packages(),
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
**v0.2.0** April 23, 2020
  * Changes
    * Dropped support for Python 3.5 (#128)
    * Rename LabelTimes.name to LabelTimes.label_name (#126)
    * Support keyword arguments in Pandas methods. (#121)
  * Documentation Changes
    * Improved data download in Predict Next Purchase (#76)
  * Testing Changes
    * Added tests that use Python 3.8 in CirlceCI (#128)

  **Breaking Changes**
  * `LabelTimes.name` has been renamed to `LabelTimes.label_name`