### PR TITLE
Sampling From Group

### DIFF
--- a/composeml/label_times/object.py
+++ b/composeml/label_times/object.py
@@ -449,17 +449,25 @@ class LabelTimes(pd.DataFrame):
             'per_instance': per_instance,
         }
 
-        def transform(lt):
-            key, value = ('n', n) if n else ('frac', frac)
-            assert value, "must set value for 'n' or 'frac'"
+        key, value = ('n', n) if n else ('frac', frac)
+        assert value, "must set value for 'n' or 'frac'"
 
-            per_label = isinstance(value, dict)
-            method = lt._sample_per_label if per_label else lt._sample
-            sample = method(key, value, settings, random_state=random_state, replace=replace)
+        per_label = isinstance(value, dict)
+        method = '_sample_per_label' if per_label else '_sample'
+
+        def transform(lt):
+            sample = getattr(lt, method)(
+                key=key,
+                value=value,
+                settings=settings,
+                random_state=random_state,
+                replace=replace,
+            )
             return sample
 
         if per_instance:
-            sample = self.groupby(self.target_entity, group_keys=False).apply(transform)
+            groupby = self.groupby(self.target_entity, group_keys=False)
+            sample = groupby.apply(transform)
         else:
             sample = transform(self)
 

--- a/composeml/label_times/object.py
+++ b/composeml/label_times/object.py
@@ -375,7 +375,7 @@ class LabelTimes(pd.DataFrame):
         sample = pd.concat(sample_per_label, axis=0, sort=False)
         return sample
 
-    def sample(self, n=None, frac=None, random_state=None, replace=False):
+    def sample(self, n=None, frac=None, random_state=None, replace=False, per_instance=False):
         """Return a random sample of labels.
 
         Args:
@@ -385,6 +385,7 @@ class LabelTimes(pd.DataFrame):
                 the sample fraction to each label. Cannot be used with n.
             random_state (int) : Seed for the random number generator.
             replace (bool) : Sample with or without replacement. Default value is False.
+            per_instance (bool): Whether to apply sampling to each group. Default is False.
 
         Returns:
             LabelTimes : Random sample of labels.

--- a/composeml/label_times/object.py
+++ b/composeml/label_times/object.py
@@ -12,6 +12,7 @@ SCHEMA_VERSION = "0.1.0"
 
 class LabelTimes(pd.DataFrame):
     """The data frame that contains labels and cutoff times for the target entity."""
+
     def __init__(
         self,
         data=None,

--- a/composeml/tests/test_label_transforms/test_sample.py
+++ b/composeml/tests/test_label_transforms/test_sample.py
@@ -1,6 +1,6 @@
 import pytest
-
-from composeml.tests.utils import to_csv
+from composeml import LabelTimes
+from composeml.tests.utils import read_csv, to_csv
 
 
 @pytest.fixture
@@ -97,3 +97,25 @@ def test_single_target(total_spent):
     match = 'must first select an individual target'
     with pytest.raises(AssertionError, match=match):
         lt.sample(2)
+
+
+def test_sample_per_instance():
+    data = read_csv([
+        'target_entity,labels',
+        '0,a',
+        '1,a',
+        '0,b',
+        '1,b',
+    ])
+
+    lt = LabelTimes(data=data, target_entity='target_entity')
+    sample = lt.sample({'a': 1}, per_instance=True, random_state=0)
+    actual = to_csv(sample, index=False)
+
+    expected = [
+        'target_entity,labels',
+        '0,a',
+        '1,a',
+    ]
+
+    assert expected == actual

--- a/composeml/tests/test_label_transforms/test_sample.py
+++ b/composeml/tests/test_label_transforms/test_sample.py
@@ -100,7 +100,7 @@ def test_single_target(total_spent):
         lt.sample(2)
 
 
-def test_sample_per_instance():
+def test_sample_n_per_instance():
     data = read_csv([
         'target_entity,labels',
         '0,a',
@@ -110,11 +110,36 @@ def test_sample_per_instance():
     ])
 
     lt = LabelTimes(data=data, target_entity='target_entity')
-    sample = lt.sample({'a': 1}, per_instance=True, random_state=0)
+    sample = lt.sample(n={'a': 1}, per_instance=True, random_state=0)
     actual = to_csv(sample, index=False)
 
     expected = [
         'target_entity,labels',
+        '0,a',
+        '1,a',
+    ]
+
+    assert expected == actual
+
+
+def test_sample_frac_per_instance():
+    data = read_csv([
+        'target_entity,labels',
+        '0,a',
+        '0,a',
+        '0,a',
+        '0,a',
+        '1,a',
+        '1,a',
+    ])
+
+    lt = LabelTimes(data=data, target_entity='target_entity')
+    sample = lt.sample(frac={'a': .5}, per_instance=True, random_state=0)
+    actual = to_csv(sample, index=False)
+
+    expected = [
+        'target_entity,labels',
+        '0,a',
         '0,a',
         '1,a',
     ]

--- a/composeml/tests/test_label_transforms/test_sample.py
+++ b/composeml/tests/test_label_transforms/test_sample.py
@@ -76,6 +76,7 @@ def test_sample_in_transforms(labels):
         'frac': None,
         'random_state': None,
         'replace': False,
+        'per_instance': False,
     }
 
     sample = labels.sample(n=n)

--- a/composeml/tests/test_label_transforms/test_sample.py
+++ b/composeml/tests/test_label_transforms/test_sample.py
@@ -104,8 +104,8 @@ def test_sample_per_instance():
     data = read_csv([
         'target_entity,labels',
         '0,a',
-        '1,a',
         '0,b',
+        '1,a',
         '1,b',
     ])
 

--- a/composeml/tests/test_label_transforms/test_sample.py
+++ b/composeml/tests/test_label_transforms/test_sample.py
@@ -1,4 +1,5 @@
 import pytest
+
 from composeml import LabelTimes
 from composeml.tests.utils import read_csv, to_csv
 


### PR DESCRIPTION
Closes #124 by adding the parameter `per_instance`, which determines whether or not the sampling should be applied to each group. Working through the code, it made sense to make this parameter boolean. This added more functionality by allowing users to sample a fraction of the labels from each group. 

#### Example

```python
>>> lt
```

```
   entity labels
0       0      a
1       0      a
2       0      b
3       0      b
4       1      a
5       1      a
6       1      b
7       1      b
```

```python
>>> frac = {'a': 1, 'b': .5}
>>> lt.sample(frac=frac, per_instance=True)
```

```
   entity labels
0       0      a
1       0      a
2       0      b
4       1      a
5       1      a
7       1      b
```